### PR TITLE
feat: add support for forwarding attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,19 @@ npm install svelte-lazy-image
   alt="Lorem Ipsum"
 />
 ```
+
+The component uses `$$restProps` to pass props other than `placeholder`, `src`, or `alt` to the underlying `img` element. An example using `img` attributes `srcset` and `sizes`:
+
+```html
+<script>
+  import LazyImage from 'svelte-lazy-image';
+</script>
+
+<LazyImage
+  src="https://via.placeholder.com/250?text=src"
+  placeholder="https://via.placeholder.com/250?text=placeholder"
+  alt="Lorem Ipsum"
+  srcset="https://via.placeholder.com/480 480w, https://via.placeholder.com/800 800w"
+  sizes="(max-width: 600px) 480px, 800px"
+/>
+```

--- a/package.json
+++ b/package.json
@@ -31,5 +31,5 @@
     "index.mjs",
     "index.js"
   ],
-  "version": "0.0.3"
+  "version": "0.1.0"
 }

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -44,6 +44,7 @@
   {alt}
   on:load={handleLoad}
   bind:this={imgElement}
+  {...$$restProps}
   class="svelte-lazy-image"
   class:svelte-lazy-image--loaded={loaded}
 />


### PR DESCRIPTION
Add support for forwarding props/attributes not declared by export to underlying img element.

Forward image attributes to img #2