### PR TITLE
Add option to pass additional classes to the image tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
     "index.js",
     "types"
   ],
-  "version": "0.2.0"
+  "version": "0.4.0"
 }

--- a/src/LazyImage.svelte
+++ b/src/LazyImage.svelte
@@ -1,8 +1,8 @@
 <script>
   import { onMount } from "svelte";
 
-  let observerCallback = function (entries, observer) {
-    entries.forEach((entry) => {
+  let observerCallback = function(entries, observer) {
+    entries.forEach(entry => {
       if (entry.isIntersecting) {
         intersected = true;
         observer.unobserve(imgElement);

--- a/src/LazyImage.svelte
+++ b/src/LazyImage.svelte
@@ -28,7 +28,7 @@
    */
   export let alt;
 
-  const propsClasses = $$restProps.class ? " " + $$restProps.class : "";
+  $: cssClass = $$props.class || "";
 
   let imgElement;
   let path;
@@ -61,6 +61,6 @@
   on:load={handleLoad}
   bind:this={imgElement}
   {...$$restProps}
-  class="svelte-lazy-image{propsClasses}"
+  class="svelte-lazy-image {cssClass}"
   class:svelte-lazy-image--loaded={loaded}
 />

--- a/src/LazyImage.svelte
+++ b/src/LazyImage.svelte
@@ -1,8 +1,8 @@
 <script>
   import { onMount } from "svelte";
 
-  let observerCallback = function(entries, observer) {
-    entries.forEach(entry => {
+  let observerCallback = function (entries, observer) {
+    entries.forEach((entry) => {
       if (entry.isIntersecting) {
         intersected = true;
         observer.unobserve(imgElement);
@@ -28,6 +28,8 @@
    */
   export let alt;
 
+  const propsClasses = $$restProps.class ? " " + $$restProps.class : "";
+
   let imgElement;
   let path;
 
@@ -38,7 +40,7 @@
   $: path = intersected ? src : placeholder;
 
   onMount(() => {
-    observer = new IntersectionObserver(observerCallback)
+    observer = new IntersectionObserver(observerCallback);
     observer.observe(imgElement);
 
     return () => {
@@ -59,6 +61,6 @@
   on:load={handleLoad}
   bind:this={imgElement}
   {...$$restProps}
-  class="svelte-lazy-image"
+  class="svelte-lazy-image{propsClasses}"
   class:svelte-lazy-image--loaded={loaded}
 />


### PR DESCRIPTION
Hi Alex -  Appreciate your work on this elegant component! Using it currently, i found I needed to pass some additional classes to the LazyImage, but they were getting discarded.

This PR pulls any `class` property (string) from `$$restProps` and appends it to the `svelte-lazy-image` class on the element. If there's none, it adds nothing. (Note: it seems I can't do a typed `export let class` because it's a JS keyword.)

Let me know if I can improve this.

Use:
```svelte
<LazyImage
  class="card-img-top other classes"
  src={node.imgSrcSm}
  placeholder={node.imgSrcThumb}
  alt={node.textName}
  srcset="{node.imgSrcThumb} 480w, {node.imgSrcSm} 800w"
  sizes="(max-width: 600px) 480px, 800px"
/>
```